### PR TITLE
Add missing dependency on pluginlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(laser_proc)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs rosconsole nodelet)
+find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs rosconsole nodelet pluginlib)
 
 ###################################################
 ## Declare things to be passed to other projects ##

--- a/package.xml
+++ b/package.xml
@@ -19,11 +19,13 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rosconsole</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>pluginlib</build_depend>
   <build_depend>nodelet</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>rosconsole</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>pluginlib</run_depend>
   <run_depend>nodelet</run_depend>
   
   <export>


### PR DESCRIPTION
Nodelet does not pass along pluginlib implicitly, because pluginlib is not used in any exposed headers.  This is correct behavior on nodelet's behalf.

This library directly imports pluginlib:

https://github.com/ros-perception/laser_proc/blob/groovy-devel/src/LaserProcNodelet.cpp#L59

And therefore this package should depend on pluginlib explicitly.
