### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/src/LaserProcNodelet.cpp
+++ b/src/LaserProcNodelet.cpp
@@ -57,5 +57,5 @@ private:
 }
 
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(laser_proc, LaserProcNodelet, laser_proc::LaserProcNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(laser_proc::LaserProcNodelet, nodelet::Nodelet)
 


### PR DESCRIPTION
This macro, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)
