### PR TITLE
Make the laser_proc library shared.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
 
-add_library(laser_proc
+add_library(laser_proc SHARED
   src/laser_proc.cpp
   src/laser_publisher.cpp
 )


### PR DESCRIPTION
This will help it link on Linux when building as a component.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@Karsten1987 FYI, this is part of what I had to do to get the whole URG node building.