### PR TITLE
Use C-style strings for RCLCPP_ macros.

### DIFF
--- a/src/laser_publisher.cpp
+++ b/src/laser_publisher.cpp
@@ -157,7 +157,7 @@ void LaserPublisher::publish(const sensor_msgs::msg::MultiEchoLaserScan & msg) c
       } catch (std::runtime_error & e) {
         auto err = std::string("Could not publish to topic ") + impl_->pubs_[i]->get_topic_name();
         auto logger = rclcpp::get_logger("laser_publisher");
-        RCLCPP_ERROR(logger, err);
+        RCLCPP_ERROR(logger, "%s", err.c_str());
         RCLCPP_ERROR(logger, e.what());
       }
     }
@@ -187,7 +187,7 @@ void LaserPublisher::publish(sensor_msgs::msg::MultiEchoLaserScan::ConstSharedPt
       } catch (std::runtime_error & e) {
         auto err = std::string("Could not publish to topic ") + impl_->pubs_[i]->get_topic_name();
         auto logger = rclcpp::get_logger("laser_publisher");
-        RCLCPP_ERROR(logger, err);
+        RCLCPP_ERROR(logger, "%s", err.c_str());
         RCLCPP_ERROR(logger, e.what());
       }
     }


### PR DESCRIPTION
Since https://github.com/ros2/rclcpp/pull/1442 , only
C-style strings can be used with the RCLCPP_ macros.
More information is available in
https://index.ros.org/doc/ros2/Releases/Release-Galactic-Geochelone/#change-in-rclcpp-s-logging-macros

Fix the code here to use C-style strings.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>