### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ target_include_directories(laser_proc
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-ament_target_dependencies(laser_proc
+target_link_libraries(laser_proc PUBLIC
   rclcpp
   sensor_msgs
 )
@@ -36,7 +36,7 @@ target_compile_definitions(${PROJECT_NAME}
 ## Laser Proc component
 add_library(laser_proc_component SHARED src/laser_proc_component.cpp)
 target_link_libraries(laser_proc_component laser_proc)
-ament_target_dependencies(laser_proc_component
+target_link_libraries(laser_proc_component PUBLIC
   class_loader
 )
 rclcpp_components_register_node(laser_proc_component

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,9 +35,8 @@ target_compile_definitions(${PROJECT_NAME}
 
 ## Laser Proc component
 add_library(laser_proc_component SHARED src/laser_proc_component.cpp)
-target_link_libraries(laser_proc_component laser_proc)
-target_link_libraries(laser_proc_component PUBLIC
-  class_loader
+target_link_libraries(laser_proc_component laser_proc
+  PUBLIC class_loader
 )
 rclcpp_components_register_node(laser_proc_component
   PLUGIN "laser_proc::LaserProcComponent"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,9 @@ target_include_directories(laser_proc
   $<INSTALL_INTERFACE:include>
 )
 target_link_libraries(laser_proc PUBLIC
-  rclcpp
-  sensor_msgs
+  ${sensor_msgs_TARGETS}
+  rclcpp::rclcpp
+  sensor_msgs::sensor_msgs_library
 )
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
@@ -35,8 +36,9 @@ target_compile_definitions(${PROJECT_NAME}
 
 ## Laser Proc component
 add_library(laser_proc_component SHARED src/laser_proc_component.cpp)
-target_link_libraries(laser_proc_component laser_proc
-  PUBLIC class_loader
+target_link_libraries(laser_proc_component PUBLIC
+  laser_proc
+  class_loader::class_loader
 )
 rclcpp_components_register_node(laser_proc_component
   PLUGIN "laser_proc::LaserProcComponent"


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
